### PR TITLE
Remove unused import in favour of own type

### DIFF
--- a/src/ResultsTable.tsx
+++ b/src/ResultsTable.tsx
@@ -1,6 +1,6 @@
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
-import TableCell, { SortDirection } from '@mui/material/TableCell';
+import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';


### PR DESCRIPTION
We don't use the `SortDirection` type defined in the MUI library.